### PR TITLE
[#13]FIX: fix predicting task to use embedding vector of cls token

### DIFF
--- a/infra/task_module.py
+++ b/infra/task_module.py
@@ -118,7 +118,7 @@ class HFBertTask(pl.LightningModule):
 
         outputs = self.predict_model(**batch)
         # pooler_outputs = outputs['pooler_output'] # these are the sentence embedding vectors (768 dim each)
-        pooler_outputs = outputs[1] # for torchscript
+        pooler_outputs = outputs[0][:, 0] # for torchscript
         outputs_concated = []
         for i in range(int(len(pooler_outputs) / len(self.predict_target_cols))):
             outputs_concated.append(torch.concat(list(pooler_outputs[i * len(self.predict_target_cols):(i + 1) * len(self.predict_target_cols)])))

--- a/utils/handling_requests.py
+++ b/utils/handling_requests.py
@@ -50,11 +50,11 @@ def find_matched_lectures(jd_pd, udemy_pd, keyword_jds_pd, keyword_udemy_pd):
     # udemy, 공고 사이에 겹치는 키워드를 추출하는 함수
     def make_keywords(keyword_jds_pd, keyword_udemy_pd):
         keywords = pd.merge(keyword_jds_pd, keyword_udemy_pd, on = '단어명', how = 'inner')['단어명'].values
-        
+
         return keywords
 
     keywords = make_keywords(keyword_jds_pd, keyword_udemy_pd)
-    
+
     # 중복된 키워드 안에서 JD 안에 있는 keyword를 추출
     k_list = []
     for keyword in keywords:
@@ -68,12 +68,12 @@ def find_matched_lectures(jd_pd, udemy_pd, keyword_jds_pd, keyword_udemy_pd):
         Udemy_string = udemy_pd.loc[idx, '강의소개'] + udemy_pd.loc[idx, '강의명']
         Udemy_string = Udemy_string.lower().replace(' ', '')
         count = 0
-        
+
         for key in k_list:
             count += Udemy_string.count(key)
-            
+
         Rec_dict[idx] = count
-    
+
     Rec_dict = dict(sorted(Rec_dict.items(), key = lambda x: x[1], reverse = True))
-    
+
     return Rec_dict


### PR DESCRIPTION
## [#13] FIX : pooler output 대신 cls 토큰의 embedding vector 를 사용하는 안

## 🌱 작업한 내용

- task module 의 prediction 파트 수정

## 📮 관련 이슈

- Resolved: #13
