### PR TITLE
Fix/#21 QnA기반 mock_JD제작 성능을 올리기 위한 함수 FIX

### DIFF
--- a/utils/handling_data.py
+++ b/utils/handling_data.py
@@ -119,17 +119,17 @@ def generate_v_jd(QnA_answer: dict):
                 for i in answer:
                         jd_dic['자격요건'] += (i + '능력을 가지고 계신분\n'
                                             )
-                        
+
                         jd_dic['우대조건'] += (i + '능력을 가지고 계신분\n'
                                             )
-                        
+
                         jd_dic['회사소개'] += (i + '문화를 가지고 있는 회사 입니다.\n'
                                            )
 
             case 'stack':
                 if len(answer) == 0:
                     pass
-                
+
                 else:
                     for i in answer:
                         jd_dic['자격요건'] += (i + '개발 경험이 있으신 분\n'
@@ -139,17 +139,17 @@ def generate_v_jd(QnA_answer: dict):
                                             + i + '에 관심이 있으신 분'
                                             + '기술스택: ' + ','.join(i)
                                             )
-                        
+
                         jd_dic['우대조건'] += (i + '사용에 능숙하신 분\n'
                                            + i + '개발 경험이 있으신 분\n'
                                            + i + '개발 경험'
                                            )
-                    
+
             #default '수습' in welfare
             case 'welfare':
                 if '수습' not in answer:
                     jd_dic['복지'] = ''
-                
+
                 if '장비' in answer:
                     jd_dic['복지'] += '필요한 장비지원\n장비 구매 지원\n'
 
@@ -158,7 +158,7 @@ def generate_v_jd(QnA_answer: dict):
 
                 if '출퇴근' in answer:
                      jd_dic['복지'] += '유연근무제를 시행중입니다.\n재택근무를 시행중\n'
-                
+
                 if '식사' in answer:
                      jd_dic['복지'] += '구내식당, 사내식당\n중/석식비 제공, 식사비 제공\n'
 
@@ -170,7 +170,7 @@ def generate_v_jd(QnA_answer: dict):
 
                 if '계발' in answer:
                      jd_dic['복지'] += '온라인강의 제공\n 도서, 시험지 제공\n자기계발비 지원'
-                    
+
 
             case 'job':
                 if len(answer) == 0:
@@ -181,10 +181,10 @@ def generate_v_jd(QnA_answer: dict):
                                             + i + '에 대한 지식을 보유하고 있는 분\n'
                                             + i + '관련 지식 보유\n'
                                             )
-                        
+
                         jd_dic['주요업무'] += (i + '관련 연구 및 개발\n'
                                            )
-                        
+
                         jd_dic['우대조건'] += (i + '관련 프로젝트 경험이 있는분\n'
                                             + i + '에 대한 지식을 보유하고 있는 분\n'
                                             + i + '관련 지식 보유\n'
@@ -192,20 +192,20 @@ def generate_v_jd(QnA_answer: dict):
 
 
             case 'domain':
-                
+
                 for i in answer:
                     jd_dic['회사소개'] += (i + '관련 프로젝트 경험이 있는분\n'
                                         + i + '에 대한 지식을 보유하고 있는 분\n'
                                         + i + '관련 지식 보유\n'
                                         )
-                    
+
                     jd_dic['우대조건'] += (i + '에 대한 지식을 보유하고 있는 분\n'
                                         + i + '관련 지식 보유\n'
                                         )
 
                     jd_dic['주요업무'] += (i + '관련 연구 및 개발\n'
                                            )
-  
+
   return jd_dic
 
 async def update_udemy_data(file):

--- a/utils/handling_data.py
+++ b/utils/handling_data.py
@@ -110,39 +110,102 @@ def embedding_v_jds(v_jd_dict, target_columns = ['자격요건', '우대조건',
   return output_pooler.view((1, -1))
 
 def generate_v_jd(QnA_answer: dict):
-  jd_dic = {'자격요건':'','우대조건':'','복지':'수습','회사소개':'','주요업무':''}
+  jd_dic = {'자격요건':'','우대조건':'','복지':'수습기간 급여지급\n수습기간 적용\n','회사소개':'','주요업무':''}
 
-  for key, value in QnA_answer.items():
-    question = key
-    answer = ' '.join(value)
+  for question, answer in QnA_answer.items():
 
-    match question:
-      case 'personality':
-        jd_dic['자격요건'] = jd_dic['자격요건'] + answer +' '
-        jd_dic['회사소개'] = jd_dic['회사소개'] + answer +' '
+        match question:
+            case 'personality':
+                for i in answer:
+                        jd_dic['자격요건'] += (i + '능력을 가지고 계신분\n'
+                                            )
+                        
+                        jd_dic['우대조건'] += (i + '능력을 가지고 계신분\n'
+                                            )
+                        
+                        jd_dic['회사소개'] += (i + '문화를 가지고 있는 회사 입니다.\n'
+                                           )
 
-      case 'stack':
-        if len(answer) == 0:
-          pass
+            case 'stack':
+                if len(answer) == 0:
+                    pass
+                
+                else:
+                    for i in answer:
+                        jd_dic['자격요건'] += (i + '개발 경험이 있으신 분\n'
+                                            + i + '개발 경험\n'
+                                            + i + '사용이 가능하신 분\n'
+                                            + i + '에대한 이해\n'
+                                            + i + '에 관심이 있으신 분'
+                                            + '기술스택: ' + ','.join(i)
+                                            )
+                        
+                        jd_dic['우대조건'] += (i + '사용에 능숙하신 분\n'
+                                           + i + '개발 경험이 있으신 분\n'
+                                           + i + '개발 경험'
+                                           )
+                    
+            #default '수습' in welfare
+            case 'welfare':
+                if '수습' not in answer:
+                    jd_dic['복지'] = ''
+                
+                if '장비' in answer:
+                    jd_dic['복지'] += '필요한 장비지원\n장비 구매 지원\n'
 
-        else:
-          jd_dic['자격요건'] = jd_dic['자격요건'] + answer +' '
-          jd_dic['우대조건'] = jd_dic['우대조건'] + answer +' '
+                if '휴가' in answer:
+                     jd_dic['복지'] += '휴가 지원\n연차\n'
 
-      #default '수습' in welfare
-      case 'welfare':
-        if '수습' not in answer:
-          jd_dic['복지'] = answer
-        else:
-          jd_dic['복지'] = jd_dic['복지'] + answer +' '
+                if '출퇴근' in answer:
+                     jd_dic['복지'] += '유연근무제를 시행중입니다.\n재택근무를 시행중\n'
+                
+                if '식사' in answer:
+                     jd_dic['복지'] += '구내식당, 사내식당\n중/석식비 제공, 식사비 제공\n'
 
-      case 'job':
-        jd_dic['주요업무'] = jd_dic['주요업무'] + answer +' '
+                if '건강검진' in answer:
+                     jd_dic['복지'] += '건강검진 지원\n '
+
+                if '인센티브' in answer:
+                     jd_dic['복지'] += '인센티브 제공\n스톡옵션 제공\n성과에 따른 보상 제공\n'
+
+                if '계발' in answer:
+                     jd_dic['복지'] += '온라인강의 제공\n 도서, 시험지 제공\n자기계발비 지원'
+                    
+
+            case 'job':
+                if len(answer) == 0:
+                    pass
+
+                for i in answer:
+                        jd_dic['자격요건'] += (i + '관련 프로젝트 경험이 있는분\n'
+                                            + i + '에 대한 지식을 보유하고 있는 분\n'
+                                            + i + '관련 지식 보유\n'
+                                            )
+                        
+                        jd_dic['주요업무'] += (i + '관련 연구 및 개발\n'
+                                           )
+                        
+                        jd_dic['우대조건'] += (i + '관련 프로젝트 경험이 있는분\n'
+                                            + i + '에 대한 지식을 보유하고 있는 분\n'
+                                            + i + '관련 지식 보유\n'
+                                           )
 
 
-      case 'domain':
-        jd_dic['회사소개'] = jd_dic['회사소개'] + answer +' '
+            case 'domain':
+                
+                for i in answer:
+                    jd_dic['회사소개'] += (i + '관련 프로젝트 경험이 있는분\n'
+                                        + i + '에 대한 지식을 보유하고 있는 분\n'
+                                        + i + '관련 지식 보유\n'
+                                        )
+                    
+                    jd_dic['우대조건'] += (i + '에 대한 지식을 보유하고 있는 분\n'
+                                        + i + '관련 지식 보유\n'
+                                        )
 
+                    jd_dic['주요업무'] += (i + '관련 연구 및 개발\n'
+                                           )
+  
   return jd_dic
 
 async def update_udemy_data(file):

--- a/utils/handling_requests.py
+++ b/utils/handling_requests.py
@@ -51,7 +51,7 @@ def get_recommended_jds(id, columns, start, end):
 
 
 def find_matched_jds(vec_mock, vec_origin, start, end, target_columns = ['자격요건', '우대조건', '복지', '회사소개', '주요업무']) -> list:
-    result = []
+    result_df = pd.DataFrame()
     col_dic = {'자격요건':0,'우대조건':1,'복지':2,'회사소개':3,'주요업무':4}
     col_list = [col_dic.get(col) for col in target_columns if col in col_dic]
 
@@ -59,9 +59,16 @@ def find_matched_jds(vec_mock, vec_origin, start, end, target_columns = ['자격
     origins = torch.chunk(vec_origin, chunks=5, dim=1)
 
     for col_idx in col_list:
-        result.append(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1))
+        if col_idx == 2  or col_idx == 3:
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)/2)
+        elif col_idx ==0 or col_idx ==1:
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)*2)
+        else:
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)*1.5)
 
-    return (sum(result)/len(col_list)).argsort()[start:end]
+    sorted_idx = result_df.mean(axis=1).sort_values(ascending=False)
+
+    return sorted_idx.index[start:end]
 
 
 def statistics_extracting(recommends_data: list, tech_stack: dict) -> (str, dict):

--- a/utils/handling_requests.py
+++ b/utils/handling_requests.py
@@ -60,11 +60,11 @@ def find_matched_jds(vec_mock, vec_origin, start, end, target_columns = ['자격
 
     for col_idx in col_list:
         if col_idx == 2  or col_idx == 3:
-            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)/2)
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0), origins[col_idx], dim=1).detach() / 2)
         elif col_idx ==0 or col_idx ==1:
-            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)*2)
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0), origins[col_idx], dim=1).detach() * 2)
         else:
-            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0),origins[col_idx], dim=1)*1.5)
+            result_df[col_idx] = pd.Series(torch.nn.functional.cosine_similarity(mocks[col_idx].unsqueeze(0), origins[col_idx], dim=1).detach() * 1.5)
 
     sorted_idx = result_df.mean(axis=1).sort_values(ascending=False)
 


### PR DESCRIPTION
## [#21] FIX: QnA기반 mock_JD제작 성능을 올리기 위한 함수 FIX

## 🌱 작업한 내용

- QnA질문을 받은 output을  단순히 단어나열이 아닌 문장을 추가하여 실제 공고와 더 유사하게 만듬
-> 문장선정은 공고에서 자주나오는 문구로 선정
- Cosine유사도를 계산하고 공고를 뽑아내는 함수 수정
-> 기존의 계산방식의 문제점 발견하고 수정(column별로 나눈 tensor자체를 sum해버림)
-> 계산시 중요하지 않은 column의 가중치는 올리고 상대적으로 중요하지 않은 column의 가중치는 내림

## 🌱 PR Point

- 함수 내부 logic만 변화시킴

## 📮 관련 이슈

- Resolved: #21 
